### PR TITLE
Implement a handler for file header

### DIFF
--- a/src/rdata_internal.h
+++ b/src/rdata_internal.h
@@ -6,13 +6,6 @@
 
 #pragma pack(push, 1)
 
-typedef struct rdata_v2_header_s {
-    char       header[2];
-    uint32_t   format_version;
-    uint32_t   writer_version;
-    uint32_t   reader_version;
-} rdata_v2_header_t;
-
 typedef struct rdata_sexptype_header_s {
     unsigned int   type:8;
     unsigned int   object:1;
@@ -78,3 +71,6 @@ typedef struct rdata_sexptype_info_s {
 #define RDATA_SEXPTYPE_LANGUAGE_OBJECT_ATTR    240
 #define RDATA_SEXPTYPE_PAIRLIST_ATTR           239
 #define RDATA_PSEUDO_SXP_ALTREP                238
+
+/* we read this many characters from the beginning of the file to determine file format */
+#define RDATA_HEADER_LENGTH 5

--- a/src/rdata_parser.c
+++ b/src/rdata_parser.c
@@ -63,6 +63,11 @@ rdata_error_t rdata_set_error_handler(rdata_parser_t *parser, rdata_error_handle
     return RDATA_OK;
 }
 
+rdata_error_t rdata_set_header_handler(rdata_parser_t *parser, rdata_header_handler header_handler) {
+    parser->header_handler = header_handler;
+    return RDATA_OK;
+}
+
 rdata_error_t rdata_set_open_handler(rdata_parser_t *parser, rdata_open_handler open_handler) {
     parser->io->open = open_handler;
     return RDATA_OK;

--- a/src/rdata_write.c
+++ b/src/rdata_write.c
@@ -243,7 +243,7 @@ rdata_error_t rdata_begin_file(rdata_writer_t *writer, void *user_ctx) {
             goto cleanup;
     }
 
-    rdata_v2_header_t v2_header;
+    rdata_header_t v2_header;
     memcpy(v2_header.header, "X\n", sizeof("X\n")-1);
     v2_header.format_version = 2;
     v2_header.reader_version = 131840;


### PR DESCRIPTION
 This allows clients to learn the file version, compression, writer version, etc. Before, this information was impossible to extract from the library.

This is really useful to inform end users ahead of time whether given file is supported or not, and if not - why (for example because lack of support for ASCII mode or version 1 files in librdata).

The change is backwards compatible because the newly added handler `header_handler` is optional and in older code it will simply not be called.