### PR TITLE
Fix error in decompressing RDS files that decompress to more than UINT_MAX bytes

### DIFF
--- a/src/rdata_read.c
+++ b/src/rdata_read.c
@@ -241,6 +241,7 @@ static ssize_t read_st_compression(rdata_ctx_t *ctx, void *buffer, size_t len) {
 
 #if HAVE_ZLIB
 static ssize_t read_st_z(rdata_ctx_t *ctx, void *buffer, size_t len) {
+    const uInt max = (uInt)-1;
     ssize_t bytes_written = 0;
     int error = 0;
     int result = Z_OK;
@@ -248,7 +249,10 @@ static ssize_t read_st_z(rdata_ctx_t *ctx, void *buffer, size_t len) {
         long start_out = ctx->z_strm->total_out;
 
         ctx->z_strm->next_out = (unsigned char *)buffer + bytes_written;
-        ctx->z_strm->avail_out = len - bytes_written;
+        if (ctx->z_strm->avail_out == 0) {
+            ssize_t left = len - bytes_written;
+            ctx->z_strm->avail_out = left > (ssize_t)max ? max : (uInt)left;
+        }
 
         result = inflate(ctx->z_strm, Z_SYNC_FLUSH);
 


### PR DESCRIPTION
When decompressing RDS files that decompress to more than `UINT_MAX` bytes (~4 GB), librdata incorrectly returns an error `Could not open file`.

This is caused by truncating assignment of an 8 byte `ssize_t` to a 4 byte `uInt`. I fixed this by doing saturating assignment instead. The surrounding decompression loop ensures that larger files can be decompressed (in chunks).

C.f https://github.com/madler/zlib/blob/develop/uncompr.c#L58 for a reference implementation that works this way.

I only fixed the bug that I could personally confirm fixed with my changes, the analogous functions using gzip or lzma decompression likely still have similar bugs.

Please consider turning on the `-Wconversion` flag for gcc, as this correctly warns about the assignment that caused this bug. When briefly turning on `-Wconversion`, I got a large number of warnings about other lines in the codebase. 